### PR TITLE
fix drag-and-drop inside child elements issue

### DIFF
--- a/front_end_dev/drag-and-drop-example/index.html
+++ b/front_end_dev/drag-and-drop-example/index.html
@@ -16,7 +16,7 @@
 	    <div id="draggable-6" class="example-draggable" draggable="true" ondragstart="onDragStart(event);">Lambda</div>
 	  </div>
 	</div>
-	<div class="example-dropzone" ondragover="onDragOver(event);" ondrop="onDrop(event);">dropzone</div>
+	<div id = "dropzone-1" class="example-dropzone" ondragover="onDragOver(event);" ondrop="onDrop(event);">dropzone</div>
 	</div>
 	<script src="script.js"></script>
   </body>

--- a/front_end_dev/drag-and-drop-example/script.js
+++ b/front_end_dev/drag-and-drop-example/script.js
@@ -8,6 +8,8 @@ function onDragStart(event) {
 //DataTransfer obj keeps track of info related to current drag
 //first param for setData: string telling format of 2nd param
 //2nd param: actual data being transferred
+  if (event.target.parentElement.className == "dropzone")
+  {}
   event
   	.dataTransfer
     .setData('text/plain', event.target.id);
@@ -23,6 +25,30 @@ function onDragOver(event) {
 	event.preventDefault();
 }
 
+//event target is dom that triggered event
+//need to make sure we can't affect something with a target
+//but note this fires every 350 ms
+function allowDrop(event) {
+    var t = event.target;
+    // Find the drop target
+    //console.log(t.classList.contains("target"))
+    console.log(t);
+    while (t !== null && !t.classList.contains("example-dropzone")) {
+        console.log("YEET1");
+        console.log(t.classList);
+        t = t.parentNode;
+        console.log("YEET2");
+    }
+
+    // If the target is empty allow the drop.
+    if (t && t.childNodes.length == 0) {
+        event.preventDefault();
+    }
+    return false;
+}
+
+//one solution to prevent elements in dropzone having elements added to them (readonly)
+
 function onDrop(event) {
 	const id = event
 				.dataTransfer
@@ -34,21 +60,31 @@ function onDrop(event) {
     const draggableElementCopy = draggableElement.cloneNode(true);
     //get parent of draggable element
     const parent_of_draggable_element = draggableElement.parentElement;	
-	console.info(dropzone);
+	
 	//add element to drop zone
 	dropzone.appendChild(draggableElement);
+	//now check whether there exists an element in the parent that matches the dragged node	
+	//console.log(draggableElementCopy)
+    console.log(parent_of_draggable_element)
+    parent_of_draggable_element.appendChild(draggableElementCopy);
+
+    //hack to prevent draggable element from being something that can be dragged into another?
+    var parentName = draggableElement.parentElement.className;
+    var stuff = document.getElementById("dropzone-1");
+    //console.log(parentName);
+    //console.log(stuff);
+    //basically alert issue with dropping draggable element
+    if (parentName.startsWith("example-draggable")) {
+    	//remove from where it is now
+    	//draggableElement.id = "temp_id";
+    	draggableElement.parentElement.removeChild(draggableElement);
+    	alert("Can't do this, sorry");
+    }
 	event
 		.dataTransfer
-		.clearData();
-	//now check whether there exists an element in the parent that matches the dragged node	
-	console.log(draggableElementCopy)
-    console.log(parent_of_draggable_element)
-    parent_of_draggable_element.appendChild(draggableElementCopy);	
+		.clearData();    
 }
 
-//need to do this to consider the case where drag fails
-//without this, nothing should be broken, but we should end up seeing
-//an extra element
 function onDragEnd(event) {
 	//get id of element being dragged
 	const id = event

--- a/front_end_dev/drag-and-drop-example/style.css
+++ b/front_end_dev/drag-and-drop-example/style.css
@@ -18,6 +18,7 @@
   margin-bottom: 10px;
   margin-top: 10px;
   padding: 10px;
+  border-style: solid;
 }
 
 .example-dropzone {


### PR DESCRIPTION
Was able to block dragging into en element in the dropzone (not perfect, but works). However, still there is issue where dragging and moving elements in the dropzone creates a new copy of that element. Need to allow dragging of elements in the dropzone. 